### PR TITLE
Add getLocale to Player to get the locale the client is using.

### DIFF
--- a/src/main/java/net/canarymod/api/entity/living/humanoid/Player.java
+++ b/src/main/java/net/canarymod/api/entity/living/humanoid/Player.java
@@ -508,4 +508,11 @@ public interface Player extends Human, MessageReceiver {
      * @return time played
      */
     public long getTimePlayed();
+
+    /**
+     * Gets the locale the player is using in their client. This is in the format of language_region e.g. en_US
+     *
+     * @return the player's locale
+     */
+    public String getLocale();
 }


### PR DESCRIPTION
This returns a locale in the same format the client uses, e.g. en_US or en_PT

I did not see anything that offers similarly functionality in the API already. This is certainly the smallest diff that can be done. If wanted, a `Locale` object could be added instead of the raw locale string which exposes the Language / Region portion of the locale code.

**Testing**

I have tested this well using LWC's rewrite which supports Canary Recode. LWC can support multiple languages and when it knows the client's language it can automatically send them text in their native language (not the default language) if a translation is available.

The same idea could definitely be applied to other plugins or even an abstracted localization library in general.
